### PR TITLE
Change input name for the Slack sign-up

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -29,7 +29,7 @@
 <form action="/invite" method="post">
   <div class="combined">
     <label for="email">Sign up for our slack</label>
-    <input type="email" id="email" name="name" placeholder="Enter your email">
+    <input type="email" id="email" name="email" placeholder="Enter your email">
     <button type="submit">Sign up</button>
   </div>
 </form>


### PR DESCRIPTION
The input tag in the Slack sign-up form had the wrong name. The name was "name" rather than "email" and the Express route is looking for the name "email". As a result, the if statement in the route is failing because req.body.email doesn't exist. The HTML is providing req.body.name. Rather than change the Express route I just renamed the name of the input tag. I changed it to "email" using the Chrome Developer Tool (too lazy to do a full clone using git) and everything worked.
